### PR TITLE
Fix prod tag name

### DIFF
--- a/cloud_run/deploy.sh
+++ b/cloud_run/deploy.sh
@@ -31,7 +31,7 @@ function deploy-stg () {
 }
 
 function deploy-prd () {
-  deploy "prd-${1:-$(date +%FT%TZ)}"
+  deploy "prd-${1:-$(date +%FT%H.%M.%SZ)}"
 }
 
 # -----------------------------


### PR DESCRIPTION
Git does not allow `:`.
So the new format is with dots (eg. `prd-2021-03-24T11.26.54Z`)